### PR TITLE
78 detail top bar actions

### DIFF
--- a/app/src/main/kotlin/com/architects/pokearch/core/framework/mediaplayer/AndroidMediaPlayerSource.kt
+++ b/app/src/main/kotlin/com/architects/pokearch/core/framework/mediaplayer/AndroidMediaPlayerSource.kt
@@ -13,23 +13,24 @@ class AndroidMediaPlayerSource @Inject constructor(
     @ApplicationContext private val context: Context,
     private val mediaPlayer: MediaPlayer
 ): MediaPlayerDataSource {
+
     override suspend fun playCry(url: String) {
         mediaPlayCry(url)
     }
 
     private fun mediaPlayCry(url: String){
-        try {
-            mediaPlayer.apply {
-                setAudioAttributes(getAudioAtrributes())
-                setDataSource(context, url.toUri())
-                prepare()
-                start()
+            try {
+                mediaPlayer.apply {
+                    reset()
+                    setAudioAttributes(getAudioAtrributes())
+                    setDataSource(context, url.toUri())
+                    prepare()
+                    start()
+                }
+            } catch (e: Exception){
+                Log.e(this.javaClass.simpleName, e.stackTraceToString())
+                mediaPlayer.release()
             }
-        } catch (e: Exception){
-            Log.e(this.javaClass.simpleName, e.message.toString())
-            mediaPlayer.stop()
-            mediaPlayer.release()
-        }
     }
 
     private fun getAudioAtrributes() =

--- a/app/src/main/kotlin/com/architects/pokearch/ui/features/details/ui/DetailScreen.kt
+++ b/app/src/main/kotlin/com/architects/pokearch/ui/features/details/ui/DetailScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
@@ -69,17 +68,19 @@ import com.architects.pokearch.ui.components.extensions.statColor
 import com.architects.pokearch.ui.components.image.ArchAsyncImage
 import com.architects.pokearch.ui.components.progressIndicators.ArchLoadingIndicator
 import com.architects.pokearch.ui.features.details.state.DetailUiState
+import com.architects.pokearch.ui.features.details.state.DetailUiState.Success
 import com.architects.pokearch.ui.features.details.viewModel.DetailViewModel
 import com.architects.pokearch.ui.theme.SetStatusBarColor
 
 @Composable
 fun DetailScreen(
+    onBack: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: DetailViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.pokemonDetailInfo.collectAsStateWithLifecycle()
 
-    Container(
+    Box(
         modifier = Modifier.fillMaxSize()
     ) {
 
@@ -92,7 +93,7 @@ fun DetailScreen(
                 Text(text = "Error")
             }
 
-            is DetailUiState.Success -> {
+            is Success -> {
                 viewModel.playCry()
                 DetailSuccessScreen(
                     modifier = modifier,
@@ -100,13 +101,19 @@ fun DetailScreen(
                 )
             }
         }
+
+        DetailTopBar(
+            onBack = onBack,
+            uiState = uiState,
+            onFavorite = { viewModel.toggleFavorite() }
+        )
     }
 }
 
 @Composable
 private fun DetailSuccessScreen(
     modifier: Modifier = Modifier,
-    state: DetailUiState.Success,
+    state: Success,
 ) {
 
     val (image, colors) = getGradientImageAndColors(pokemonInfo = state.pokemonInfo)
@@ -175,20 +182,7 @@ private fun getGradientImageAndColors(
         colors = it.ifEmpty { colorsDefault }
     }
 
-    return(Pair(image, colors))
-}
-
-@Composable
-private fun Container(
-    modifier: Modifier,
-    content: @Composable BoxScope.() -> Unit
-) {
-    Box(
-        modifier = modifier.fillMaxSize(),
-        propagateMinConstraints = true,
-    ) {
-        content()
-    }
+    return (Pair(image, colors))
 }
 
 @Composable
@@ -294,7 +288,9 @@ private fun PokemonInfos(
     ) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
-            modifier = Modifier.weight(1f).padding(vertical = 16.dp)
+            modifier = Modifier
+                .weight(1f)
+                .padding(vertical = 16.dp)
         ) {
             Row {
                 Icon(
@@ -332,7 +328,9 @@ private fun PokemonInfos(
 
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
-            modifier = Modifier.weight(1f).padding(vertical = 16.dp)
+            modifier = Modifier
+                .weight(1f)
+                .padding(vertical = 16.dp)
         ) {
             Row {
                 Icon(

--- a/app/src/main/kotlin/com/architects/pokearch/ui/features/details/ui/DetailTopBar.kt
+++ b/app/src/main/kotlin/com/architects/pokearch/ui/features/details/ui/DetailTopBar.kt
@@ -1,0 +1,66 @@
+package com.architects.pokearch.ui.features.details.ui
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.FavoriteBorder
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import com.architects.pokearch.ui.features.details.state.DetailUiState
+
+@Composable
+@OptIn(ExperimentalMaterial3Api::class)
+fun DetailTopBar(
+    onBack: () -> Unit,
+    uiState: DetailUiState,
+    onFavorite: () -> Unit,
+) {
+    TopAppBar(
+        title = { },
+        navigationIcon = {
+            IconButton(
+                onClick = { onBack() },
+                colors = iconButtonColors()
+            ) {
+                Icon(imageVector = Icons.Default.ArrowBack, contentDescription = null)
+            }
+        },
+        actions = {
+            if (uiState is DetailUiState.Success) {
+                IconButton(
+                    onClick = { onFavorite() },
+                    colors = iconButtonColors()
+                ) {
+                    Icon(
+                        imageVector =
+                        if (uiState.pokemonInfo.team) Icons.Default.Favorite
+                        else Icons.Default.FavoriteBorder,
+                        contentDescription = null
+                    )
+                }
+            }
+        },
+        colors = topAppBarColors(),
+    )
+}
+
+@Composable
+private fun iconButtonColors() =
+    IconButtonDefaults.iconButtonColors(
+        containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.30f)
+    )
+
+@Composable
+@OptIn(ExperimentalMaterial3Api::class)
+private fun topAppBarColors() = TopAppBarDefaults.topAppBarColors(
+    containerColor = Color.Transparent,
+    navigationIconContentColor = MaterialTheme.colorScheme.onSurface,
+    actionIconContentColor = MaterialTheme.colorScheme.onSurface
+)

--- a/app/src/main/kotlin/com/architects/pokearch/ui/navigation/Navigation.kt
+++ b/app/src/main/kotlin/com/architects/pokearch/ui/navigation/Navigation.kt
@@ -8,8 +8,8 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation
 import com.architects.pokearch.ui.features.details.ui.DetailScreen
-import com.architects.pokearch.ui.features.shakeNCatch.ui.ShakeNCatchScreen
 import com.architects.pokearch.ui.features.home.ui.HomeScreen
+import com.architects.pokearch.ui.features.shakeNCatch.ui.ShakeNCatchScreen
 import com.architects.pokearch.ui.features.team.TeamScreen
 
 @Composable
@@ -22,14 +22,15 @@ fun Navigation(
         navController = navHostController,
         startDestination = Feature.MAIN.route
     ){
-        homeNav(pokemonName, onNavigationDetailClick)
+        homeNav(navHostController, pokemonName, onNavigationDetailClick)
         teamNav()
-        randomCatchNav(onNavigationDetailClick)
+        randomCatchNav(navHostController, onNavigationDetailClick)
     }
 
 }
 
 fun NavGraphBuilder.homeNav(
+    navHostController: NavHostController,
     pokemonName: String,
     onNavigationDetailClick: (String) -> Unit,
 ){
@@ -48,7 +49,9 @@ fun NavGraphBuilder.homeNav(
             )
         }
         composable(NavCommand.ContentDetail(Feature.MAIN)){
-            DetailScreen()
+            DetailScreen(
+                onBack = { navHostController.popBackStack() }
+            )
         }
     }
 }
@@ -65,6 +68,7 @@ fun NavGraphBuilder.teamNav(){
 }
 
 fun NavGraphBuilder.randomCatchNav(
+    navHostController: NavHostController,
     onNavigationDetailClick: (String) -> Unit,
 ){
     navigation(
@@ -81,7 +85,7 @@ fun NavGraphBuilder.randomCatchNav(
             )
         }
         composable(NavCommand.ContentDetail(Feature.RANDOM)){
-            DetailScreen()
+            DetailScreen(onBack = { navHostController.popBackStack() })
         }
     }
 }

--- a/data/src/main/kotlin/com/architects/pokearch/data/repository/PokeArchRepository.kt
+++ b/data/src/main/kotlin/com/architects/pokearch/data/repository/PokeArchRepository.kt
@@ -53,6 +53,9 @@ class PokeArchRepository @Inject constructor(
         }
     }
 
+    override suspend fun updatePokemonInfo(pokemonInfo: PokemonInfo) =
+        localDataSource.savePokemonInfo(pokemonInfo)
+
     private suspend fun getRemotePokemon(
         id: Int,
     ): Either<Failure, PokemonInfo> = remoteDataSource.getPokemon(id)

--- a/domain/src/main/kotlin/com/architects/pokearch/domain/repository/PokeArchRepositoryContract.kt
+++ b/domain/src/main/kotlin/com/architects/pokearch/domain/repository/PokeArchRepositoryContract.kt
@@ -1,9 +1,9 @@
 package com.architects.pokearch.domain.repository
 
 import arrow.core.Either
-import com.architects.pokearch.domain.model.error.Failure
 import com.architects.pokearch.domain.model.Pokemon
 import com.architects.pokearch.domain.model.PokemonInfo
+import com.architects.pokearch.domain.model.error.Failure
 import kotlinx.coroutines.flow.Flow
 
 interface PokeArchRepositoryContract {
@@ -17,6 +17,8 @@ interface PokeArchRepositoryContract {
     suspend fun fetchPokemonList(): Failure?
 
     suspend fun fetchPokemonInfo(id: Int): Flow<Either<Failure, PokemonInfo>>
+
+    suspend fun updatePokemonInfo(pokemonInfo: PokemonInfo)
 
     suspend fun fetchCry(name: String): String
 

--- a/usecases/src/main/kotlin/com/architects/pokearch/usecases/UpdatePokemonInfo.kt
+++ b/usecases/src/main/kotlin/com/architects/pokearch/usecases/UpdatePokemonInfo.kt
@@ -1,0 +1,12 @@
+package com.architects.pokearch.usecases
+
+import com.architects.pokearch.domain.model.PokemonInfo
+import com.architects.pokearch.domain.repository.PokeArchRepositoryContract
+import javax.inject.Inject
+
+class UpdatePokemonInfo @Inject constructor(
+    private val pokeArchRepository: PokeArchRepositoryContract
+) {
+    suspend operator fun invoke(pokemon: PokemonInfo) =
+        pokeArchRepository.updatePokemonInfo(pokemon)
+}


### PR DESCRIPTION
🎩 How was this resolved?

Cambios Realizados:
Pequeño fix en el uso del Media Player, empezó a fallarme continuamente y cerrarme la app.
Top bar independiente del scaffold para detalle. 
La top bar se superpone con la parte superior de la card con la imagen del Pokémon.
Contiene un iconButton para volver atrás y otro para cambiar el estado de favorito del Pokémon.

Detalles Adicionales:

Instrucciones para Revisión:

Otros Cambios:

