### PR TITLE
71 shake n catch unit tests

### DIFF
--- a/app/src/main/kotlin/com/architects/pokearch/ui/features/shakeNCatch/state/ShakeNCatchUiState.kt
+++ b/app/src/main/kotlin/com/architects/pokearch/ui/features/shakeNCatch/state/ShakeNCatchUiState.kt
@@ -5,7 +5,7 @@ import com.architects.pokearch.domain.model.PokemonInfo
 data class ShakeNCatchUiState(
     val openedPokeball: Boolean = false,
     val acceleration: Float = 0f,
-    val isLoading: Boolean = true,
+    val isLoading: Boolean = false,
     val error: Boolean = false,
     val pokemonInfo: PokemonInfo? = null,
     val onDetail: Boolean = false

--- a/app/src/main/kotlin/com/architects/pokearch/ui/features/shakeNCatch/viewModel/ShakeNCatchViewModel.kt
+++ b/app/src/main/kotlin/com/architects/pokearch/ui/features/shakeNCatch/viewModel/ShakeNCatchViewModel.kt
@@ -41,8 +41,10 @@ class ShakeNCatchViewModel @Inject constructor(
         private const val accelerationThreshold = 8
     }
 
-    private var accelerationMin = 0f
-    private var accelerationMax = 0f
+    var accelerationMin = 0f
+        private set
+    var accelerationMax = 0f
+        private set
 
     init {
         collectAccelerometerValue()
@@ -74,6 +76,7 @@ class ShakeNCatchViewModel @Inject constructor(
         viewModelScope.launch(dispatcher) {
             uiState.map { it.openedPokeball }.distinctUntilChanged().collect { openPokeball ->
                 if (openPokeball) {
+                    _uiState.update { it.copy(isLoading = true) }
                     vibrate()
                     getRandomPokemon().collectLatest { result ->
                         result.fold(

--- a/app/src/test/kotlin/com/architects/pokearch/core/framework/database/mapper/DomainMapperTest.kt
+++ b/app/src/test/kotlin/com/architects/pokearch/core/framework/database/mapper/DomainMapperTest.kt
@@ -4,10 +4,10 @@ import com.architects.pokearch.samples.database.pokemonEntityListBuilder
 import com.architects.pokearch.samples.database.pokemonInfoEntityBuilder
 import com.architects.pokearch.samples.database.pokemonInfoEntityListBuilder
 import com.architects.pokearch.samples.database.statsHolderBuilder
-import com.architects.pokearch.testing.rules.samples.pokemonInfoBuilder
-import com.architects.pokearch.testing.rules.samples.pokemonInfoListBuilder
-import com.architects.pokearch.testing.rules.samples.pokemonListBuilder
-import com.architects.pokearch.testing.rules.samples.statsBuilder
+import com.architects.pokearch.testing.samples.pokemonInfoBuilder
+import com.architects.pokearch.testing.samples.pokemonInfoListBuilder
+import com.architects.pokearch.testing.samples.pokemonListBuilder
+import com.architects.pokearch.testing.samples.statsBuilder
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Test
 

--- a/app/src/test/kotlin/com/architects/pokearch/core/framework/database/mapper/RealEntityMapperTest.kt
+++ b/app/src/test/kotlin/com/architects/pokearch/core/framework/database/mapper/RealEntityMapperTest.kt
@@ -6,12 +6,12 @@ import com.architects.pokearch.samples.database.pokemonInfoEntityBuilder
 import com.architects.pokearch.samples.database.pokemonInfoEntityListBuilder
 import com.architects.pokearch.samples.database.statsHolderBuilder
 import com.architects.pokearch.samples.database.typesHolderBuilder
-import com.architects.pokearch.testing.rules.samples.pokemonBuilder
-import com.architects.pokearch.testing.rules.samples.pokemonInfoBuilder
-import com.architects.pokearch.testing.rules.samples.pokemonInfoListBuilder
-import com.architects.pokearch.testing.rules.samples.pokemonListBuilder
-import com.architects.pokearch.testing.rules.samples.statsBuilder
-import com.architects.pokearch.testing.rules.samples.typesBuilder
+import com.architects.pokearch.testing.samples.pokemonBuilder
+import com.architects.pokearch.testing.samples.pokemonInfoBuilder
+import com.architects.pokearch.testing.samples.pokemonInfoListBuilder
+import com.architects.pokearch.testing.samples.pokemonListBuilder
+import com.architects.pokearch.testing.samples.statsBuilder
+import com.architects.pokearch.testing.samples.typesBuilder
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Test
 

--- a/app/src/test/kotlin/com/architects/pokearch/core/framework/network/mapper/NetworkMappersTest.kt
+++ b/app/src/test/kotlin/com/architects/pokearch/core/framework/network/mapper/NetworkMappersTest.kt
@@ -8,11 +8,11 @@ import com.architects.pokearch.samples.network.networkPokemonInfoListBuilder
 import com.architects.pokearch.samples.network.networkPokemonListBuilder
 import com.architects.pokearch.samples.network.networkStatsBuilder
 import com.architects.pokearch.samples.network.networkTypesBuilder
-import com.architects.pokearch.testing.rules.samples.pokemonInfoBuilder
-import com.architects.pokearch.testing.rules.samples.pokemonInfoListBuilder
-import com.architects.pokearch.testing.rules.samples.pokemonListBuilder
-import com.architects.pokearch.testing.rules.samples.statsBuilder
-import com.architects.pokearch.testing.rules.samples.typesBuilder
+import com.architects.pokearch.testing.samples.pokemonInfoBuilder
+import com.architects.pokearch.testing.samples.pokemonInfoListBuilder
+import com.architects.pokearch.testing.samples.pokemonListBuilder
+import com.architects.pokearch.testing.samples.statsBuilder
+import com.architects.pokearch.testing.samples.typesBuilder
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Test
 

--- a/app/src/test/kotlin/com/architects/pokearch/ui/features/shakeNCatch/viewModel/ShakeNCatchViewModelTest.kt
+++ b/app/src/test/kotlin/com/architects/pokearch/ui/features/shakeNCatch/viewModel/ShakeNCatchViewModelTest.kt
@@ -65,7 +65,7 @@ class ShakeNCatchViewModelTest {
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
-    fun `GIVEN accelerometer value is greater than 8 and greater than or equal to -8 afterWHEN init THEN states no change`() = runTest {
+    fun `GIVEN accelerometer value is greater than 8 and greater than or equal to -8 after WHEN init THEN states no change`() = runTest {
         every { getAccelerometerValue() } returns buildAccelerationFlow(9f, -8f)
 
         viewModel = buildViewModel()

--- a/app/src/test/kotlin/com/architects/pokearch/ui/features/shakeNCatch/viewModel/ShakeNCatchViewModelTest.kt
+++ b/app/src/test/kotlin/com/architects/pokearch/ui/features/shakeNCatch/viewModel/ShakeNCatchViewModelTest.kt
@@ -1,0 +1,198 @@
+package com.architects.pokearch.ui.features.shakeNCatch.viewModel
+
+import app.cash.turbine.test
+import arrow.core.left
+import arrow.core.right
+import com.architects.pokearch.R
+import com.architects.pokearch.domain.model.error.ErrorType
+import com.architects.pokearch.domain.model.error.Failure
+import com.architects.pokearch.testing.rules.MainDispatcherRule
+import com.architects.pokearch.testing.samples.pokemonInfoBuilder
+import com.architects.pokearch.testing.verifications.coVerifyNever
+import com.architects.pokearch.testing.verifications.coVerifyOnce
+import com.architects.pokearch.testing.verifications.verifyNever
+import com.architects.pokearch.testing.verifications.verifyOnce
+import com.architects.pokearch.ui.features.shakeNCatch.state.ShakeNCatchUiState
+import com.architects.pokearch.ui.mapper.ErrorDialogManager
+import com.architects.pokearch.usecases.GetAccelerometerValue
+import com.architects.pokearch.usecases.GetRandomPokemon
+import com.architects.pokearch.usecases.Vibrate
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class ShakeNCatchViewModelTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val getAccelerometerValue: GetAccelerometerValue = mockk()
+    private val getRandomPokemon: GetRandomPokemon = mockk()
+    private val vibrate: Vibrate = mockk()
+    private val errorDialogManager: ErrorDialogManager = ErrorDialogManager()
+
+    private lateinit var viewModel: ShakeNCatchViewModel
+
+    @Before
+    fun setUp() {
+        every { getAccelerometerValue() } returns buildAccelerationFlow()
+        coEvery { getRandomPokemon() } returns flowOf(pokemonInfoBuilder().right())
+        justRun { vibrate() }
+    }
+
+    @Test
+    fun `GIVEN accelerometer value is 0 WHEN init THEN states no change`() = runTest {
+        viewModel = buildViewModel()
+
+        viewModel.uiState.test {
+            awaitItem() shouldBeEqualTo  ShakeNCatchUiState()
+        }
+        verifyOnce { getAccelerometerValue() }
+        coVerifyNever { getRandomPokemon() }
+        verifyNever { vibrate() }
+        viewModel.dialogState.value shouldBeEqualTo null
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `GIVEN accelerometer value is greater than 8 and greater than or equal to -8 afterWHEN init THEN states no change`() = runTest {
+        every { getAccelerometerValue() } returns buildAccelerationFlow(9f, -8f)
+
+        viewModel = buildViewModel()
+
+        viewModel.uiState.test {
+            awaitItem() shouldBeEqualTo  ShakeNCatchUiState()
+        }
+        advanceUntilIdle()
+        verifyOnce { getAccelerometerValue() }
+        coVerifyNever { getRandomPokemon() }
+        verifyNever { vibrate() }
+        viewModel.dialogState.value shouldBeEqualTo null
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `GIVEN accelerometer value is less than or equal to 8 and less than -8 after WHEN init THEN states no change`() = runTest {
+        every { getAccelerometerValue() } returns buildAccelerationFlow(8f, -9f)
+
+        viewModel = buildViewModel()
+
+        viewModel.uiState.test {
+            awaitItem() shouldBeEqualTo  ShakeNCatchUiState()
+        }
+        advanceUntilIdle()
+        verifyOnce { getAccelerometerValue() }
+        coVerifyNever { getRandomPokemon() }
+        verifyNever { vibrate() }
+        viewModel.dialogState.value shouldBeEqualTo null
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `GIVEN accelerometer value is greater than 8 and less than -8 after WHEN init with success THEN get random pokemon`() = runTest {
+        every { getAccelerometerValue() } returns buildAccelerationFlow(9f, -9f)
+
+        viewModel = buildViewModel()
+
+        viewModel.uiState.test {
+            awaitItem() shouldBeEqualTo  ShakeNCatchUiState()
+            awaitItem() shouldBeEqualTo  ShakeNCatchUiState(acceleration = 9f)
+            awaitItem() shouldBeEqualTo  ShakeNCatchUiState(acceleration = -9f)
+            awaitItem() shouldBeEqualTo  ShakeNCatchUiState(
+                openedPokeball = true,
+                acceleration = -9f,
+                pokemonInfo = pokemonInfoBuilder()
+            )
+        }
+        advanceUntilIdle()
+        verifyOnce { getAccelerometerValue() }
+        coVerifyOnce { getRandomPokemon() }
+        verifyOnce { vibrate() }
+        viewModel.dialogState.value shouldBeEqualTo null
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `GIVEN accelerometer value is greater than 8 and less than -8 after WHEN init with error THEN get failure`() = runTest {
+        val expetedErrorTitle = R.string.error_title_no_internet
+        val expetedErrorMessage = R.string.error_message_no_internet
+        every { getAccelerometerValue() } returns buildAccelerationFlow(9f, -9f)
+        coEvery { getRandomPokemon() } returns flowOf(Failure.NetworkError(ErrorType.NoInternet).left())
+
+        viewModel = buildViewModel()
+
+        viewModel.uiState.test {
+            awaitItem() shouldBeEqualTo  ShakeNCatchUiState()
+            awaitItem() shouldBeEqualTo  ShakeNCatchUiState(acceleration = 9f)
+            awaitItem() shouldBeEqualTo  ShakeNCatchUiState(acceleration = -9f)
+            awaitItem() shouldBeEqualTo  ShakeNCatchUiState(
+                openedPokeball = true,
+                acceleration = -9f,
+                error = true
+            )
+        }
+        advanceUntilIdle()
+        verifyOnce { getAccelerometerValue() }
+        coVerifyOnce { getRandomPokemon() }
+        verifyOnce { vibrate() }
+        viewModel.dialogState.value?.title shouldBeEqualTo expetedErrorTitle
+        viewModel.dialogState.value?.message shouldBeEqualTo expetedErrorMessage
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `GIVEN accelerometer value is 9 and -9 after WHEN afterNavigation THEN onDetail is true and accelerationMinMax is 0`() = runTest {
+        every { getAccelerometerValue() } returns buildAccelerationFlow(9f, -9f)
+        viewModel = buildViewModel()
+        advanceUntilIdle()
+
+        viewModel.afterNavigation()
+
+        viewModel.uiState.test {
+            awaitItem() shouldBeEqualTo  ShakeNCatchUiState(onDetail = true)
+        }
+        viewModel.accelerationMin shouldBeEqualTo 0f
+        viewModel.accelerationMax shouldBeEqualTo 0f
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `GIVEN onDetail is true WHEN backFromDetail THEN onDetail is false`() = runTest {
+        every { getAccelerometerValue() } returns buildAccelerationFlow(9f, -9f)
+        viewModel = buildViewModel()
+        viewModel.afterNavigation()
+        advanceUntilIdle()
+
+        viewModel.backFromDetail()
+
+        viewModel.uiState.test {
+            awaitItem() shouldBeEqualTo  ShakeNCatchUiState(onDetail = false)
+        }
+    }
+
+    private fun buildViewModel() = ShakeNCatchViewModel(
+            getAccelerometerValue = getAccelerometerValue,
+            getRandomPokemon = getRandomPokemon,
+            vibrate = vibrate,
+            dispatcher = mainDispatcherRule.testDispatcher,
+            errorDialogManager = errorDialogManager
+        )
+
+    private fun buildAccelerationFlow(firstChange: Float = 0f, secondChange: Float = 0f) = flow {
+        emit(0f)
+        delay(100)
+        emit(firstChange)
+        delay(100)
+        emit(secondChange)
+    }
+}

--- a/testing/src/main/kotlin/com/architects/pokearch/testing/samples/PokemonInfoSample.kt
+++ b/testing/src/main/kotlin/com/architects/pokearch/testing/samples/PokemonInfoSample.kt
@@ -1,4 +1,4 @@
-package com.architects.pokearch.testing.rules.samples
+package com.architects.pokearch.testing.samples
 
 import com.architects.pokearch.domain.model.PokemonInfo
 import com.architects.pokearch.domain.model.Stat

--- a/testing/src/main/kotlin/com/architects/pokearch/testing/samples/PokemonSample.kt
+++ b/testing/src/main/kotlin/com/architects/pokearch/testing/samples/PokemonSample.kt
@@ -1,4 +1,4 @@
-package com.architects.pokearch.testing.rules.samples
+package com.architects.pokearch.testing.samples
 
 import com.architects.pokearch.domain.model.Pokemon
 

--- a/testing/src/main/kotlin/com/architects/pokearch/testing/verifications/coVerifyNever.kt
+++ b/testing/src/main/kotlin/com/architects/pokearch/testing/verifications/coVerifyNever.kt
@@ -1,0 +1,36 @@
+package com.architects.pokearch.testing.verifications
+
+import io.mockk.MockK
+import io.mockk.MockKDsl
+import io.mockk.MockKVerificationScope
+import io.mockk.Ordering
+
+fun coVerifyNever(
+    ordering: Ordering = Ordering.UNORDERED,
+    inverse: Boolean = false,
+    atLeast: Int = 1,
+    atMost: Int = Int.MAX_VALUE,
+    timeout: Long = 0,
+    verifyBlock: suspend MockKVerificationScope.() -> Unit
+) = MockK.useImpl {
+    MockKDsl.internalCoVerify(
+        ordering,
+        inverse,
+        atLeast,
+        atMost,
+        0,
+        timeout,
+        verifyBlock,
+    )
+}
+
+fun verifyNever(
+    ordering: Ordering = Ordering.UNORDERED,
+    inverse: Boolean = false,
+    atLeast: Int = 1,
+    atMost: Int = Int.MAX_VALUE,
+    timeout: Long = 0,
+    verifyBlock: MockKVerificationScope.() -> Unit
+) = MockK.useImpl {
+    MockKDsl.internalVerify(ordering, inverse, atLeast, atMost, 0, timeout, verifyBlock)
+}

--- a/testing/src/main/kotlin/com/architects/pokearch/testing/verifications/coVerifyOnce.kt
+++ b/testing/src/main/kotlin/com/architects/pokearch/testing/verifications/coVerifyOnce.kt
@@ -1,0 +1,36 @@
+package com.architects.pokearch.testing.verifications
+
+import io.mockk.MockK
+import io.mockk.MockKDsl
+import io.mockk.MockKVerificationScope
+import io.mockk.Ordering
+
+fun coVerifyOnce(
+    ordering: Ordering = Ordering.UNORDERED,
+    inverse: Boolean = false,
+    atLeast: Int = 1,
+    atMost: Int = Int.MAX_VALUE,
+    timeout: Long = 0,
+    verifyBlock: suspend MockKVerificationScope.() -> Unit
+) = MockK.useImpl {
+    MockKDsl.internalCoVerify(
+        ordering,
+        inverse,
+        atLeast,
+        atMost,
+        1,
+        timeout,
+        verifyBlock,
+    )
+}
+
+fun verifyOnce(
+    ordering: Ordering = Ordering.UNORDERED,
+    inverse: Boolean = false,
+    atLeast: Int = 1,
+    atMost: Int = Int.MAX_VALUE,
+    timeout: Long = 0,
+    verifyBlock: MockKVerificationScope.() -> Unit
+) = MockK.useImpl {
+    MockKDsl.internalVerify(ordering, inverse, atLeast, atMost, 1, timeout, verifyBlock)
+}


### PR DESCRIPTION
🎩 How was this resolved?

Cambios Realizados:
Añadidos los test de ShakeNCatchViewModel.

Detalles Adicionales:
Utilizo advanceUntilIdle() a pesar de utilizar turbine para asegurarme de que no hay nada pendiente. 
Se que no es necesario, pero si por ejemplo solo llamamos al primer awaitItem, cuando hay más, puede dar un falso positivo al hacer los verify por usar delay en el flow.

Dejé accelerationMaxMin con el get público y set privado para ayudarme en un test.

Instrucciones para Revisión:

Otros Cambios:
También añadí las funciones de verifyOnce y verifyNever para comprobar que los métodos se llaman una única vez o ninguna.

